### PR TITLE
Fix error

### DIFF
--- a/pri_q921.h
+++ b/pri_q921.h
@@ -115,7 +115,6 @@ typedef struct q921_s {
 	u_int8_t p_f:1;			/* Poll/Final bit */
 	u_int8_t n_r:7;			/* Number Received */
 #endif
-	u_int8_t fcs[2];		/* At least an FCS */
 	u_int8_t data[0];		/* Any further data */
 } __attribute__ ((packed)) q921_s;
 
@@ -133,7 +132,6 @@ typedef struct q921_u {
 	u_int8_t p_f:1;			/* Poll/Final bit */
 	u_int8_t m3:3;			/* Top 3 modifier bits */
 #endif
-	u_int8_t fcs[2];		/* At least an FCS */
 	u_int8_t data[0];		/* Any further data */
 } __attribute__ ((packed)) q921_u;
 
@@ -151,7 +149,6 @@ typedef struct q921_i {
 	u_int8_t p_f:1;			/* Poll/Final bit */	
 	u_int8_t n_r:7;			/* Number received */
 #endif
-	u_int8_t fcs[2];		/* At least an FCS */
 	u_int8_t data[0];		/* Any further data */
 } q921_i;
 

--- a/pri_q921.h
+++ b/pri_q921.h
@@ -115,8 +115,8 @@ typedef struct q921_s {
 	u_int8_t p_f:1;			/* Poll/Final bit */
 	u_int8_t n_r:7;			/* Number Received */
 #endif
-	u_int8_t data[0];		/* Any further data */
 	u_int8_t fcs[2];		/* At least an FCS */
+	u_int8_t data[0];		/* Any further data */
 } __attribute__ ((packed)) q921_s;
 
 /* An Unnumbered Format frame */
@@ -133,8 +133,8 @@ typedef struct q921_u {
 	u_int8_t p_f:1;			/* Poll/Final bit */
 	u_int8_t m3:3;			/* Top 3 modifier bits */
 #endif
-	u_int8_t data[0];		/* Any further data */
 	u_int8_t fcs[2];		/* At least an FCS */
+	u_int8_t data[0];		/* Any further data */
 } __attribute__ ((packed)) q921_u;
 
 /* An Information frame */
@@ -151,8 +151,8 @@ typedef struct q921_i {
 	u_int8_t p_f:1;			/* Poll/Final bit */	
 	u_int8_t n_r:7;			/* Number received */
 #endif
-	u_int8_t data[0];		/* Any further data */
 	u_int8_t fcs[2];		/* At least an FCS */
+	u_int8_t data[0];		/* Any further data */
 } q921_i;
 
 typedef union {

--- a/pri_q931.h
+++ b/pri_q931.h
@@ -37,7 +37,6 @@ typedef enum q931_mode {
 } q931_mode;
 
 typedef struct q931_h {
-	unsigned char raw[0];
 	u_int8_t pd;		/* Protocol Discriminator */
 #if __BYTE_ORDER == __BIG_ENDIAN
 	u_int8_t x0:4;
@@ -50,7 +49,11 @@ typedef struct q931_h {
 	u_int8_t crv[3];/*!< Call reference value */
 } __attribute__ ((packed)) q931_h;
 
-
+typedef union {
+  unsigned char raw[0];
+  q931_h h;
+} q931_union;
+  
 /* Message type header */
 typedef struct q931_mh {
 #if __BYTE_ORDER == __BIG_ENDIAN

--- a/pri_q931.h
+++ b/pri_q931.h
@@ -51,7 +51,7 @@ typedef struct q931_h {
 
 typedef union {
   unsigned char raw[0];
-  q931_h h;
+  q931_h *h;
 } q931_union;
   
 /* Message type header */

--- a/pri_q931.h
+++ b/pri_q931.h
@@ -50,8 +50,8 @@ typedef struct q931_h {
 } __attribute__ ((packed)) q931_h;
 
 typedef union {
-  unsigned char raw[0];
-  q931_h *h;
+	unsigned char raw[0];
+	q931_h *h;
 } q931_union;
   
 /* Message type header */

--- a/q921.c
+++ b/q921.c
@@ -789,7 +789,7 @@ static int q921_send_queued_iframes(struct q921_link *link)
 			 * Also dump the Q.931 part only once instead of for every
 			 * retransmission.
 			 */
-		  q931_dump(ctrl, link->tei, (q931_h *) f->h.data, f->len - 4, 1);
+			q931_dump(ctrl, link->tei, (q931_h *) f->h.data, f->len - 4, 1);
 		}
 		f->status = Q921_TX_FRAME_SENT;
 	}

--- a/q921.c
+++ b/q921.c
@@ -789,7 +789,7 @@ static int q921_send_queued_iframes(struct q921_link *link)
 			 * Also dump the Q.931 part only once instead of for every
 			 * retransmission.
 			 */
-			q931_dump(ctrl, link->tei, (q931_h *) f->h.data, f->len - 4, 1);
+		  q931_dump(ctrl, link->tei, (q931_h *) f->h.data, f->len - 4, 1);
 		}
 		f->status = Q921_TX_FRAME_SENT;
 	}

--- a/q931.c
+++ b/q931.c
@@ -7704,8 +7704,8 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	}
 	switch (h->pd) {
 	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_1:
-	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_2: 
-	        if (!ctrl->service_message_support) {
+	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_2:
+		if (!ctrl->service_message_support) {
 	 		/* Real service message support has not been enabled (and is OFF in libpri by default),
 	 		 * so we have to revert to the 'traditional' KLUDGE of changing byte 4 from a 0xf (SERVICE)
 	 		 * to a 0x7 (SERVICE ACKNOWLEDGE) */

--- a/q931.c
+++ b/q931.c
@@ -7710,7 +7710,7 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	 		/* This is the weird maintenance stuff.  We majorly 
 	 		   KLUDGE this by changing byte 4 from a 0xf (SERVICE) 
 	 		   to a 0x7 (SERVICE ACKNOWLEDGE) */
-	     ((q931_union h))->raw[h->crlen + 2] -= 0x8;
+	     ((q931_union) h)->raw[h->crlen + 2] -= 0x8;
 			q931_xmit(link, h, len, 1, 0);
 			return 0;
 		}

--- a/q931.c
+++ b/q931.c
@@ -7710,7 +7710,7 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	 		/* This is the weird maintenance stuff.  We majorly 
 	 		   KLUDGE this by changing byte 4 from a 0xf (SERVICE) 
 	 		   to a 0x7 (SERVICE ACKNOWLEDGE) */
-	 	  (q931_union) h->raw[h->crlen + 2] -= 0x8;
+	     ((q931_union h))->raw[h->crlen + 2] -= 0x8;
 			q931_xmit(link, h, len, 1, 0);
 			return 0;
 		}

--- a/q931.c
+++ b/q931.c
@@ -7677,7 +7677,7 @@ static struct q931_call *q931_get_subcall(struct q921_link *link, struct q931_ca
 int q931_receive(struct q921_link *link, q931_h *h, int len)
 {
 	q931_mh *mh;
-	q931_union h_union = h;
+	q931_union *h_union = h;
 	struct q931_call *c;
 	struct pri *ctrl;
 	q931_ie *ie;

--- a/q931.c
+++ b/q931.c
@@ -7704,13 +7704,13 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	}
 	switch (h->pd) {
 	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_1:
-	 case MAINTENANCE_PROTOCOL_DISCRIMINATOR_2: 
-	   if (!ctrl->service_message_support) { 
-	 		/* Real service message support has not been enabled (and is OFF in libpri by default), 
-	 		 * so we have to revert to the 'traditional' KLUDGE of changing byte 4 from a 0xf (SERVICE) 
+	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_2: 
+	        if (!ctrl->service_message_support) {
+	 		/* Real service message support has not been enabled (and is OFF in libpri by default),
+	 		 * so we have to revert to the 'traditional' KLUDGE of changing byte 4 from a 0xf (SERVICE)
 	 		 * to a 0x7 (SERVICE ACKNOWLEDGE) */
-	 		/* This is the weird maintenance stuff.  We majorly 
-	 		   KLUDGE this by changing byte 4 from a 0xf (SERVICE) 
+	 		/* This is the weird maintenance stuff.  We majorly
+	 		   KLUDGE this by changing byte 4 from a 0xf (SERVICE)
 	 		   to a 0x7 (SERVICE ACKNOWLEDGE) */
 	                h_union.raw[h->crlen + 2] -= 0x8;
 			q931_xmit(link, h, len, 1, 0);

--- a/q931.c
+++ b/q931.c
@@ -7677,6 +7677,7 @@ static struct q931_call *q931_get_subcall(struct q921_link *link, struct q931_ca
 int q931_receive(struct q921_link *link, q931_h *h, int len)
 {
 	q931_mh *mh;
+	q931_union h_union = h;
 	struct q931_call *c;
 	struct pri *ctrl;
 	q931_ie *ie;
@@ -7710,7 +7711,7 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	 		/* This is the weird maintenance stuff.  We majorly 
 	 		   KLUDGE this by changing byte 4 from a 0xf (SERVICE) 
 	 		   to a 0x7 (SERVICE ACKNOWLEDGE) */
-	     ((q931_union) h)->raw[h->crlen + 2] -= 0x8;
+	                h_union->raw[h->crlen + 2] -= 0x8;
 			q931_xmit(link, h, len, 1, 0);
 			return 0;
 		}

--- a/q931.c
+++ b/q931.c
@@ -7674,7 +7674,7 @@ static struct q931_call *q931_get_subcall(struct q921_link *link, struct q931_ca
 	return cur;
 }
 
-int q931_receive(struct q921_link *link, q931_union *h, int len)
+int q931_receive(struct q921_link *link, q931_h *h, int len)
 {
 	q931_mh *mh;
 	struct q931_call *c;

--- a/q931.c
+++ b/q931.c
@@ -7674,7 +7674,7 @@ static struct q931_call *q931_get_subcall(struct q921_link *link, struct q931_ca
 	return cur;
 }
 
-int q931_receive(struct q921_link *link, q931_h *h, int len)
+int q931_receive(struct q921_link *link, q931_union *h, int len)
 {
 	q931_mh *mh;
 	struct q931_call *c;

--- a/q931.c
+++ b/q931.c
@@ -7706,12 +7706,12 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_1:
 	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_2:
 		if (!ctrl->service_message_support) {
-	 		/* Real service message support has not been enabled (and is OFF in libpri by default),
-	 		 * so we have to revert to the 'traditional' KLUDGE of changing byte 4 from a 0xf (SERVICE)
-	 		 * to a 0x7 (SERVICE ACKNOWLEDGE) */
-	 		/* This is the weird maintenance stuff.  We majorly
-	 		   KLUDGE this by changing byte 4 from a 0xf (SERVICE)
-	 		   to a 0x7 (SERVICE ACKNOWLEDGE) */
+			/* Real service message support has not been enabled (and is OFF in libpri by default),
+			 * so we have to revert to the 'traditional' KLUDGE of changing byte 4 from a 0xf (SERVICE)
+			 * to a 0x7 (SERVICE ACKNOWLEDGE) */
+			/* This is the weird maintenance stuff.  We majorly
+			   KLUDGE this by changing byte 4 from a 0xf (SERVICE)
+			   to a 0x7 (SERVICE ACKNOWLEDGE) */
 	                h_union.raw[h->crlen + 2] -= 0x8;
 			q931_xmit(link, h, len, 1, 0);
 			return 0;

--- a/q931.c
+++ b/q931.c
@@ -7702,15 +7702,15 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	}
 	switch (h->pd) {
 	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_1:
-	case MAINTENANCE_PROTOCOL_DISCRIMINATOR_2:
-		if (!ctrl->service_message_support) {
-			/* Real service message support has not been enabled (and is OFF in libpri by default),
-			 * so we have to revert to the 'traditional' KLUDGE of changing byte 4 from a 0xf (SERVICE)
-			 * to a 0x7 (SERVICE ACKNOWLEDGE) */
-			/* This is the weird maintenance stuff.  We majorly
-			   KLUDGE this by changing byte 4 from a 0xf (SERVICE)
-			   to a 0x7 (SERVICE ACKNOWLEDGE) */
-			h->raw[h->crlen + 2] -= 0x8;
+	 case MAINTENANCE_PROTOCOL_DISCRIMINATOR_2: 
+	   if (!ctrl->service_message_support) { 
+	 		/* Real service message support has not been enabled (and is OFF in libpri by default), 
+	 		 * so we have to revert to the 'traditional' KLUDGE of changing byte 4 from a 0xf (SERVICE) 
+	 		 * to a 0x7 (SERVICE ACKNOWLEDGE) */
+	 		/* This is the weird maintenance stuff.  We majorly 
+	 		   KLUDGE this by changing byte 4 from a 0xf (SERVICE) 
+	 		   to a 0x7 (SERVICE ACKNOWLEDGE) */
+	 	  (q931_union) h->raw[h->crlen + 2] -= 0x8;
 			q931_xmit(link, h, len, 1, 0);
 			return 0;
 		}

--- a/q931.c
+++ b/q931.c
@@ -7677,7 +7677,7 @@ static struct q931_call *q931_get_subcall(struct q921_link *link, struct q931_ca
 int q931_receive(struct q921_link *link, q931_h *h, int len)
 {
 	q931_mh *mh;
-	q931_union *h_union = h;
+	q931_union h_union;
 	struct q931_call *c;
 	struct pri *ctrl;
 	q931_ie *ie;
@@ -7694,6 +7694,7 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	int allow_posthandle;
 	enum mandatory_ie_status mand_status;
 
+	h_union.h = h;
 	ctrl = link->ctrl;
 	memset(last_ie, 0, sizeof(last_ie));
 	ctrl->q931_rxcount++;
@@ -7711,7 +7712,7 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	 		/* This is the weird maintenance stuff.  We majorly 
 	 		   KLUDGE this by changing byte 4 from a 0xf (SERVICE) 
 	 		   to a 0x7 (SERVICE ACKNOWLEDGE) */
-	                h_union->raw[h->crlen + 2] -= 0x8;
+	                h_union.raw[h->crlen + 2] -= 0x8;
 			q931_xmit(link, h, len, 1, 0);
 			return 0;
 		}


### PR DESCRIPTION
This resolves the issue that libpri will not compile with latest GNU CC 11.

Creates union for Q.931, so data structure can be accessed as raw data, or as a structure.
Remove fcs from Q.921 data structures as this is not set or checked anywhere.