### PR TITLE
Fix compile on GNU CC 11 with -Werror

### DIFF
--- a/pri_q921.h
+++ b/pri_q921.h
@@ -116,7 +116,6 @@ typedef struct q921_s {
 	u_int8_t n_r:7;			/* Number Received */
 #endif
 	u_int8_t data[0];		/* Any further data */
-	u_int8_t fcs[2];		/* At least an FCS */
 } __attribute__ ((packed)) q921_s;
 
 /* An Unnumbered Format frame */
@@ -134,7 +133,6 @@ typedef struct q921_u {
 	u_int8_t m3:3;			/* Top 3 modifier bits */
 #endif
 	u_int8_t data[0];		/* Any further data */
-	u_int8_t fcs[2];		/* At least an FCS */
 } __attribute__ ((packed)) q921_u;
 
 /* An Information frame */
@@ -152,7 +150,6 @@ typedef struct q921_i {
 	u_int8_t n_r:7;			/* Number received */
 #endif
 	u_int8_t data[0];		/* Any further data */
-	u_int8_t fcs[2];		/* At least an FCS */
 } q921_i;
 
 typedef union {

--- a/pri_q931.h
+++ b/pri_q931.h
@@ -37,7 +37,6 @@ typedef enum q931_mode {
 } q931_mode;
 
 typedef struct q931_h {
-	unsigned char raw[0];
 	u_int8_t pd;		/* Protocol Discriminator */
 #if __BYTE_ORDER == __BIG_ENDIAN
 	u_int8_t x0:4;
@@ -50,7 +49,11 @@ typedef struct q931_h {
 	u_int8_t crv[3];/*!< Call reference value */
 } __attribute__ ((packed)) q931_h;
 
-
+typedef union {
+	unsigned char raw[0];
+	q931_h *h;
+} q931_union;
+  
 /* Message type header */
 typedef struct q931_mh {
 #if __BYTE_ORDER == __BIG_ENDIAN

--- a/q931.c
+++ b/q931.c
@@ -7677,6 +7677,7 @@ static struct q931_call *q931_get_subcall(struct q921_link *link, struct q931_ca
 int q931_receive(struct q921_link *link, q931_h *h, int len)
 {
 	q931_mh *mh;
+	q931_union h_union;
 	struct q931_call *c;
 	struct pri *ctrl;
 	q931_ie *ie;
@@ -7693,6 +7694,7 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 	int allow_posthandle;
 	enum mandatory_ie_status mand_status;
 
+	h_union.h = h;
 	ctrl = link->ctrl;
 	memset(last_ie, 0, sizeof(last_ie));
 	ctrl->q931_rxcount++;
@@ -7710,7 +7712,7 @@ int q931_receive(struct q921_link *link, q931_h *h, int len)
 			/* This is the weird maintenance stuff.  We majorly
 			   KLUDGE this by changing byte 4 from a 0xf (SERVICE)
 			   to a 0x7 (SERVICE ACKNOWLEDGE) */
-			h->raw[h->crlen + 2] -= 0x8;
+	                h_union.raw[h->crlen + 2] -= 0x8;
 			q931_xmit(link, h, len, 1, 0);
 			return 0;
 		}


### PR DESCRIPTION
Zero length arrays must be at the end of a structure.  

Introduce union into Q.931 (pri_q931.h, and q931.c) to allow raw and structure access
Remove FCS from Q.921 (pri_q921.h) as this is not set or referenced else where.

Tested using PRI over T1 between Asterisk 20.1.0, and Cisco 3845 IOS 12
