### PR TITLE
B_Channel possibly blocked after link loss in BRI Net point-to-multipoint configuration

### DIFF
--- a/q931.c
+++ b/q931.c
@@ -10201,7 +10201,7 @@ void q931_dl_event(struct q921_link *link, enum Q931_DL_EVENT event)
 						call->cr, call->channelno, call->ourcallstate,
 						q931_call_state_str(call->ourcallstate));
 				}
-				if (cur->outboundbroadcast) {
+				if (cur->outboundbroadcast && call != q931_find_winning_call(call)) {
 					/* Simply destroy non-winning subcalls. */
 					q931_destroycall(ctrl, call);
 					continue;


### PR DESCRIPTION
Fix for B-Channel not marked as free after Layer 2 down indication
while call is in Disconnect Request state.
Applies only to BRI links in Net point-to-multipoint configuration
(bri_net_ptmp).

This fix makes code consistent with existing comment in Layer 2
release indications processing.

Resolves: #5
