### PR TITLE
SETUP or RELEASE retransmission: resend UUI in retransmitted message

### DIFF
--- a/pri_internal.h
+++ b/pri_internal.h
@@ -675,6 +675,15 @@ struct q931_call {
 		/*! Encoded RESTART channel id. */
 		int channel;
 	} restart_tx;
+	/*! Message retransmission cache */
+	struct {
+		/*! Cache status: set valid as soon as filled in */
+		int valid;
+		/*! Sent message type */
+		int msgtype;
+		/*! User-user information */
+		char useruserinfo[256];
+	} retrans_cache;
 };
 
 enum CC_STATES {


### PR DESCRIPTION
When retransmitting a message, libpri currently does not include
User-user Information IE, because storage field was cleared at first
transmission.
This fix introduces a retransmission cache for information lost after
first transmission. It applies to potentially retransmitted messages:
SETUP and RELEASE.

Resolves: #7
